### PR TITLE
fix log rotation at incorrect time.

### DIFF
--- a/lib/File/RotateLogs.pm
+++ b/lib/File/RotateLogs.pm
@@ -7,6 +7,7 @@ use Fcntl qw/:DEFAULT/;
 use Proc::Daemon;
 use File::Spec;
 use Mouse;
+use Time::Local;
 
 our $VERSION = '0.02';
 
@@ -43,7 +44,9 @@ has 'sleep_before_remove' => (
 sub _gen_filename {
     my $self = shift;
     my $now = time;
-    my $time = $now - ($now % $self->rotationtime);
+    my $offset = (24 * 60 * 60) - (timegm(localtime($now)) - $now);
+
+    my $time = $now - (($now - $offset) % $self->rotationtime);
     return POSIX::strftime($self->logfile, localtime($time));
 }
 

--- a/t/02_rotate.t
+++ b/t/02_rotate.t
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+use File::Temp qw/tempdir/;
+use Test::More;
+use POSIX;
+use Time::Local;
+use Test::MockTime qw/set_fixed_time/;
+
+# load at the end
+use File::RotateLogs;
+
+my @timezones = qw( Asia/Katmandu Asia/Tokyo Austalia/Sydney UTC America/New_York Europe/Zurich );
+
+for my $timezone (@timezones) {
+    my $tempdir = tempdir(CLEANUP=>1);
+    local $ENV{TZ} = $timezone;
+    POSIX::tzset;
+
+    subtest $timezone => sub{
+        subtest '24h' => sub{
+            my $rotatelogs = File::RotateLogs->new(
+                logfile      => "$tempdir/test_log.%Y.%m.%d",
+                linkname     => "$tempdir/test_log",
+                rotationtime => 60*60*24,
+            );
+
+            set_fixed_time(timelocal(0, 0, 0, 1, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok -f "$tempdir/test_log.2013.05.01";
+
+            set_fixed_time(timelocal(0, 59, 23, 1, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok ! -f "$tempdir/test_log.2013.05.02", 'not rotate';
+            #note join "\n", glob $tempdir.'/test_log*';
+
+            set_fixed_time(timelocal(0, 0, 0, 2, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok -f "$tempdir/test_log.2013.05.02", 'rotate new file';
+        };
+        subtest '1h' => sub{
+            my $rotatelogs = File::RotateLogs->new(
+                logfile      => $tempdir.'/test_log.%Y.%m.%d.%H',
+                linkname     => $tempdir.'/test_log',
+                rotationtime => 60*60,
+            );
+
+            set_fixed_time(timelocal(0, 0, 0, 1, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok -f "$tempdir/test_log.2013.05.01.00";
+
+            set_fixed_time(timelocal(0, 59, 0, 1, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok ! -f "$tempdir/test_log.2013.05.01.01", 'not rotate';
+            #note join "\n", glob $tempdir.'/test_log*';
+
+            set_fixed_time(timelocal(0, 0, 1, 1, 5 -1, 2013));
+            $rotatelogs->print("foo\n");
+            ok -f "$tempdir/test_log.2013.05.01.01", 'rotate new file';
+        };
+    };
+};
+
+
+done_testing();


### PR DESCRIPTION
rotattiontimeを24時間に設定して、タイムゾーンがUTCじゃないときに、
logをrotateする時間とファイル名がおかしいようです。

rotateする時間を計算する箇所で、端数の時間を引いているところがepochで時差を考慮していないので、
localtimeに直すところで、時差分余計に加算されているようです。

```
## at 2013-05-31 12:35 zimezone is Asia/Tokyo
## expected filename is "2013.05.31.00.00.00" in any case.
% perl -MFile::RotateLogs -E 'say File::RotateLogs->new(logfile => "%Y.%m.%d.%H.%M.%S")->_gen_filename';
2013.05.31.09.00.00
% perl -MFile::RotateLogs -MPOSIX -E '$ENV{TZ}="UTC"; POSIX::settz; say File::RotateLogs->new(logfile => "%Y.%m.%d.%H.%M.%S")->_gen_filename';
2013.05.31.00.00.00
% perl -MFile::RotateLogs -MPOSIX -E '$ENV{TZ}="America/New_York"; POSIX::settz; say File::RotateLogs->new(logfile => "%Y.%m.%d.%H.%M.%S", rotationtime => 60*60)->_gen_filename';
2013.05.30.23.00.00
```

In case of rotationtime set 24h and not UTC timezone,
File::RotateLogs rotates at (0 + time differnce) o'clock.
