### PR TITLE
To rotate not Filename but Directory

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Mouse', '1.02';
 requires 'Proc::Daemon', '0.14';
+requires 'File::Path', '2.12';
 
 on test => sub {
     requires 'Test::More';

--- a/lib/File/RotateLogs.pm
+++ b/lib/File/RotateLogs.pm
@@ -5,6 +5,8 @@ use warnings;
 use POSIX qw//;
 use Fcntl qw/:DEFAULT/;
 use Proc::Daemon;
+use File::Basename;
+use File::Path;
 use File::Spec;
 use Mouse;
 use Mouse::Util::TypeConstraints;
@@ -92,6 +94,7 @@ sub print {
 
     unless ($fh) {
         my $is_new = ( ! -f $fname || ( $self->linkname && ! -l $self->linkname ) ) ? 1 : 0;
+        File::Path::mkpath( File::Basename::dirname($fname) );
         open $fh, '>>:utf8:unix', $fname or die "Cannot open file($fname): $!";
         if ( $is_new ) {
             eval {


### PR DESCRIPTION
Hi.

Actually, my product running by Apache.
Those log files rotate file path hourly( like below)

> CustomLog "|/usr/sbin/cronolog /var/log/httpd/%Y/%m/%d/%H/access_log"

So I would like to output as same format in Plack::MIddleware::Accesslog + File::RotateLogs 
Would you review this PR?
